### PR TITLE
[BE] 댓글 추천 시 오류 수정 + 토큰 만료 시 자동&수동 Refresh -01-

### DIFF
--- a/main_project/src/main/java/NutrientsCoders/main_project/community/service/CommunityService.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/community/service/CommunityService.java
@@ -86,8 +86,7 @@ public class CommunityService {
     }
     public Community recommendCommunity(long communityId,long memberId){
         Community findCommunityId = communityRepository.findById(communityId).orElse(null);
-        Member findMemberId = memberRepository.findByMemberId(memberId);
-        if(findMemberId.getCommunityLike() == 0 && findCommunityId.isMemberId(memberId) == false) {
+        if(findCommunityId.isMemberId(memberId) == false) {
             findCommunityId.addMembers(memberId);
             findCommunityId.setRecommendationCount(findCommunityId.incrementRecommendationCount());
             findCommunityId.setCommunityLike(1);

--- a/main_project/src/main/java/NutrientsCoders/main_project/member/entity/Member.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/member/entity/Member.java
@@ -58,8 +58,6 @@ public class Member {
 
     @Column
     private String imageUrl;
-    @Column
-    private long CommunityLike = 0;
 
     @Column(nullable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/main_project/src/main/java/NutrientsCoders/main_project/security/custom/MemberFailureHandler.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/security/custom/MemberFailureHandler.java
@@ -1,0 +1,40 @@
+package NutrientsCoders.main_project.security.custom;
+
+import NutrientsCoders.main_project.security.jwt.JwtTokenMaker;
+import NutrientsCoders.main_project.security.jwt.MemberEntryPoint;
+import NutrientsCoders.main_project.utils.AuthorityUtils;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class MemberFailureHandler implements AccessDeniedHandler {
+    private final JwtTokenMaker jwtTokenMaker;
+    private final AuthorityUtils authorityUtils;
+
+    public MemberFailureHandler(JwtTokenMaker jwtTokenMaker, AuthorityUtils authorityUtils) {
+        this.jwtTokenMaker = jwtTokenMaker;
+        this.authorityUtils = authorityUtils;
+    }
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        try{
+            System.out.println("Error Detected!");
+
+
+        }catch (ExpiredJwtException e){
+            MemberEntryPoint memberEntryPoint = new MemberEntryPoint(jwtTokenMaker, authorityUtils);
+            log.warn(e.getCause().getMessage());
+            memberEntryPoint.ifJwtExpired(request, response);
+        }
+
+    }
+}

--- a/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtAuthenticationFilter.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtAuthenticationFilter.java
@@ -82,7 +82,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     // RefreshToken 발급 과정
     private String delegateRefreshToken(Member member) {
-        String subject = member.getNickname();
+        String subject = member.getEmail();
         Date expiration = jwtmaker.getTokenExpiration(jwtmaker.getRefreshExpiration());
         String base64EncodedSecretKey = jwtmaker.encodeBase64SecretKey(jwtmaker.getSecret());
 

--- a/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtTokenMaker.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtTokenMaker.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.io.Encoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -62,6 +63,7 @@ public class JwtTokenMaker {
     }
 
     //클레임 정보 가져오기
+    @SneakyThrows
     public Jws<Claims> getClaims(String jws, String base64EncodedSecretKey) {
         Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
 

--- a/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtVerificationFilter.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/JwtVerificationFilter.java
@@ -1,6 +1,9 @@
 package NutrientsCoders.main_project.security.jwt;
 
+import NutrientsCoders.main_project.member.entity.Member;
+import NutrientsCoders.main_project.member.repository.MemberRepository;
 import NutrientsCoders.main_project.utils.AuthorityUtils;
+import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,25 +16,28 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.annotation.Target;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JwtVerificationFilter extends OncePerRequestFilter {
 
     private final JwtTokenMaker jwtTokenMaker;
     private final AuthorityUtils authorityUtils;
 
+    private final MemberRepository memberRepository;
+
     // JwtTokenMaker-> JWT를 검증하고 Claims(토큰에 포함된 정보)를 얻는 데 사용
     // Custom AuthorityUtils-> JWT 검증에 성공하면 Authentication 객체에 채울 사용자의 권한을 생성
     public JwtVerificationFilter(JwtTokenMaker jwtTokenMaker,
-                                 AuthorityUtils authorityUtils) {
+                                 AuthorityUtils authorityUtils,
+                                 MemberRepository memberRepository) {
         this.jwtTokenMaker = jwtTokenMaker;
         this.authorityUtils = authorityUtils;
+        this.memberRepository=memberRepository;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
         Map<String, Object> claims = verifyJws(request); // 1차 검증
         setAuthenticationToContext(claims);      // SecurityContext에 저장 하기 위함
 
@@ -48,12 +54,18 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
 
     private Map<String, Object> verifyJws(HttpServletRequest request) {
+        try {
+            String jws = request.getHeader("Authorization").replace("SecurityBearer ", ""); // header에서 Authorization 라고 되어있는거 가져옴 + 1차 토큰 검증
 
-        String jws = request.getHeader("Authorization").replace("SecurityBearer ", ""); // header에서 Authorization 라고 되어있는거 가져옴 + 1차 토큰 검증
+            String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
 
-        String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
-
-        return jwtTokenMaker.getClaims(jws, base64EncodedSecretKey).getBody();   // parsing
+            return jwtTokenMaker.getClaims(jws, base64EncodedSecretKey).getBody();   // parsing
+        }catch (ExpiredJwtException e){
+            System.out.println("======Refresh!======");
+            String refreshToken = request.getHeader("Refresh");
+            String newAccessToken = generateNewAccess(refreshToken);
+            return jwtTokenMaker.getClaims(newAccessToken, jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret())).getBody();   // parsing
+        }
     }
 
     private void setAuthenticationToContext(Map<String, Object> claims) {
@@ -77,5 +89,32 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 
         SecurityContextHolder.getContext().setAuthentication(authentication); // ScurityContext 저장
+    }
+
+    private String generateNewAccess(String refresh){
+
+        String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
+
+        jwtTokenMaker.verifySignature(refresh, base64EncodedSecretKey);
+
+
+        Map<String, Object> RefreshClaims = jwtTokenMaker.getClaims(refresh,jwtTokenMaker.getSecret()).getBody();
+        String email =(String) RefreshClaims.get("sub");
+        Member member = memberRepository.findByEmail(email);
+
+
+        Map<String, Object> newClaims = new HashMap<>();
+        String username = member.getNickname();
+        List<String> roles = member.getRoles();
+        newClaims.put("username", username);
+        newClaims.put("roles", roles);
+        newClaims.put("memberId",member.getMemberId());
+
+
+        Date expiration = jwtTokenMaker.getTokenExpiration(jwtTokenMaker.getAccessExpiration());
+        String AccessToken = jwtTokenMaker.generateAccessToken(newClaims, username, expiration, base64EncodedSecretKey);
+
+
+        return AccessToken;
     }
 }

--- a/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/MemberEntryPoint.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/security/jwt/MemberEntryPoint.java
@@ -1,0 +1,117 @@
+package NutrientsCoders.main_project.security.jwt;
+
+import NutrientsCoders.main_project.utils.AuthorityUtils;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+@Slf4j
+@Component
+public class MemberEntryPoint implements AuthenticationEntryPoint {
+    private final JwtTokenMaker jwtTokenMaker;
+
+    private final AuthorityUtils authorityUtils;
+
+    public MemberEntryPoint(JwtTokenMaker jwtTokenMaker, AuthorityUtils authorityUtils) {
+        this.jwtTokenMaker = jwtTokenMaker;
+        this.authorityUtils = authorityUtils;
+    }
+
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        System.out.println("hi");
+        if (authException.getCause() instanceof ExpiredJwtException){
+            ifJwtExpired(request,response);
+        }
+        try {
+            String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
+
+            jwtTokenMaker.verifySignature(request.getHeader("Authorization").replace("SecurityBearer ", ""), base64EncodedSecretKey);
+
+            if (authException.getCause() instanceof ExpiredJwtException){
+                ifJwtExpired(request,response);
+            }
+        }catch (ExpiredJwtException expiredJwtException){
+            log.warn(expiredJwtException.getMessage());
+            ifJwtExpired(request,response);
+        }
+
+
+    }
+
+    public void ifJwtExpired(HttpServletRequest request, HttpServletResponse response){
+            String refreshToken = request.getHeader("Refresh");
+
+            String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
+
+            jwtTokenMaker.verifySignature(refreshToken, base64EncodedSecretKey);
+
+            Map<String, Object> claims = takeAccess(request);
+            Map<String, Object> newClaims = new HashMap<>();
+            String username = (String) claims.get("sub");
+            List<String> roles = authorityUtils.createRoles(username);
+            newClaims.put("username", username);
+            newClaims.put("roles", roles);
+            newClaims.put("memberId",claims.get("memberId"));
+
+
+            Date expiration = jwtTokenMaker.getTokenExpiration(jwtTokenMaker.getAccessExpiration());
+            String AccessToken = jwtTokenMaker.generateAccessToken(newClaims, username, expiration, base64EncodedSecretKey);
+            String RefreshToken = jwtTokenMaker.generateRefreshToken(username,
+                    jwtTokenMaker.getTokenExpiration(jwtTokenMaker.getRefreshExpiration()),
+                    base64EncodedSecretKey);
+
+            setAuthenticationToContext(newClaims);
+
+            //새로운 액세스 토큰 응답 헤더에 담아 전송
+
+            response.setHeader("Authorization", AccessToken);
+            response.setHeader("Refresh", RefreshToken);
+
+    }
+
+    private void setAuthenticationToContext(Map<String, Object> claims) {
+        //Principal
+        Object username = claims.get("username");
+
+        //Credentials
+        Object password = claims.get("memberId"); //credentials 임시로 id
+
+
+        //Collection<GrantedAuthority>
+        List<String> roles = new ArrayList<>();
+        ArrayList<?> rolesClaim = (ArrayList<?>) claims.get("roles");
+        for (Object role : rolesClaim) {
+            if (role instanceof String) {
+                roles.add((String) role);
+            }
+        }
+
+        List<GrantedAuthority> authorities = authorityUtils.createAuthorities(roles);  // 유저 권한 가져오기
+        Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication); // ScurityContext 저장
+    }
+
+    private Map<String, Object> takeAccess(HttpServletRequest request) {
+        String jws = request.getHeader("Authorization").replace("SecurityBearer ", ""); // header에서 Authorization 라고 되어있는거 가져옴 + 1차 토큰 검증
+
+        String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
+
+        return jwtTokenMaker.getClaims(jws, base64EncodedSecretKey).getBody();   // parsing
+    }
+
+}

--- a/main_project/src/main/java/NutrientsCoders/main_project/utils/JwtController.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/utils/JwtController.java
@@ -21,7 +21,7 @@ public class JwtController {
 
 
     @GetMapping("/refresh")
-    public ResponseEntity<List<String>> refresh(@RequestHeader("Authorization")String access,
+    public ResponseEntity refresh(@RequestHeader("Authorization")String access,
                                              @RequestHeader("Refresh")String refresh){
 
         List<String> tokens = tokenChanger.getRefresh(access, refresh);
@@ -29,6 +29,6 @@ public class JwtController {
         headers.add("Authorization", tokens.get(0));
         headers.add("Refresh", tokens.get(1));
 
-        return ResponseEntity.ok().headers(headers).body(tokens);
+        return ResponseEntity.ok().headers(headers).body("refreshed");
     }
 }

--- a/main_project/src/main/java/NutrientsCoders/main_project/utils/JwtController.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/utils/JwtController.java
@@ -1,0 +1,34 @@
+package NutrientsCoders.main_project.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("")
+@Slf4j
+@CrossOrigin(origins = "*", allowedHeaders = "*")
+public class JwtController {
+
+    public JwtController(TokenChanger tokenChanger) {
+        this.tokenChanger = tokenChanger;
+    }
+
+    private final TokenChanger tokenChanger;
+
+
+    @GetMapping("/refresh")
+    public ResponseEntity<List<String>> refresh(@RequestHeader("Authorization")String access,
+                                             @RequestHeader("Refresh")String refresh){
+
+        List<String> tokens = tokenChanger.getRefresh(access, refresh);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", tokens.get(0));
+        headers.add("Refresh", tokens.get(1));
+
+        return ResponseEntity.ok().headers(headers).body(tokens);
+    }
+}

--- a/main_project/src/main/java/NutrientsCoders/main_project/utils/TokenChanger.java
+++ b/main_project/src/main/java/NutrientsCoders/main_project/utils/TokenChanger.java
@@ -1,22 +1,38 @@
 package NutrientsCoders.main_project.utils;
 
+import NutrientsCoders.main_project.member.entity.Member;
+import NutrientsCoders.main_project.member.repository.MemberRepository;
 import NutrientsCoders.main_project.security.jwt.JwtTokenMaker;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
+import java.security.Key;
+import java.util.*;
 
 @Component
+@Slf4j
 public class TokenChanger {
     private final JwtTokenMaker jwtTokenMaker;
+    private final AuthorityUtils authorityUtils;
+
+    private final MemberRepository memberRepository;
 
     @Value("${jwt.key}")
     private String secret;
 
-    public TokenChanger(JwtTokenMaker jwtTokenMaker) {
+    public TokenChanger(JwtTokenMaker jwtTokenMaker,AuthorityUtils authorityUtils,MemberRepository memberRepository) {
         this.jwtTokenMaker = jwtTokenMaker;
+        this.authorityUtils = authorityUtils;
+        this.memberRepository = memberRepository;
     }
 
     public Long getMemberId(String token){
@@ -30,5 +46,64 @@ public class TokenChanger {
         return memberId;
 
 
+    }
+
+    public List<String> getRefresh(String access,String refresh){
+        String AccessTokenChange = access.substring(15);
+        try {
+            Key key = getKeyEncoded(secret);
+
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(AccessTokenChange);
+
+            List<String> Tokens = new ArrayList<>();
+            Tokens.add(access);
+            Tokens.add(refresh);
+
+            return Tokens;
+        }catch (ExpiredJwtException e){
+
+            String base64EncodedSecretKey = jwtTokenMaker.encodeBase64SecretKey(jwtTokenMaker.getSecret());
+
+            jwtTokenMaker.verifySignature(refresh, base64EncodedSecretKey);
+
+
+            Map<String, Object> RefreshClaims = jwtTokenMaker.getClaims(refresh,secret).getBody();
+            String email =(String) RefreshClaims.get("sub");
+            Member member = memberRepository.findByEmail(email);
+
+
+            Map<String, Object> newClaims = new HashMap<>();
+            String username = member.getNickname();
+            List<String> roles = member.getRoles();
+            newClaims.put("username", username);
+            newClaims.put("roles", roles);
+            newClaims.put("memberId",member.getMemberId());
+
+
+            Date expiration = jwtTokenMaker.getTokenExpiration(jwtTokenMaker.getAccessExpiration());
+            String AccessToken = jwtTokenMaker.generateAccessToken(newClaims, username, expiration, base64EncodedSecretKey);
+
+            String RefreshToken = jwtTokenMaker.generateRefreshToken(email,
+                    jwtTokenMaker.getTokenExpiration(jwtTokenMaker.getRefreshExpiration()),
+                    base64EncodedSecretKey);
+
+
+            //새로운 액세스 토큰 응답 헤더에 담아 전송
+            List<String> Tokens = new ArrayList<>();
+            Tokens.add(AccessToken);
+            Tokens.add(RefreshToken);
+
+            return Tokens;
+        }
+
+
+    }
+    private Key getKeyEncoded(String secret) {
+        byte[] keyBytes = new byte[32];
+
+        return Keys.hmacShaKeyFor(keyBytes);
     }
 }


### PR DESCRIPTION
postman 테스트는 성공했으나, 실 재포 환경에서 되는지도 궁금하네요.

일단 

1. 댓글 추천 시 필요 없는 부분 삭제 & member에 컬럼추가로 인한 충돌 오류 수정
2. 토큰 만료 시 검증 단계에서 refresh 로 만료된 토큰 재발급후 인증 (수정이나 fix부분 있다고 생각함)
3. 수동으로 토큰 재발급(만료 시 새로운 토큰으로 리턴 )-> header로 Access,Refresh 전송
->  /refresh 주소로 Authroization 액세스와 Refresh 리프레시 토큰을 header로 보내면 됨.
